### PR TITLE
Only include file if the include path is valid.

### DIFF
--- a/lib/autoload.php
+++ b/lib/autoload.php
@@ -46,5 +46,7 @@ spl_autoload_register(function( $filename ) {
 	$fully_qualified_path .= $class_file;
 
 	// Now include the file.
-	include_once $fully_qualified_path;
+	if ( stream_resolve_include_path($fully_qualified_path) ) {
+		include_once $fully_qualified_path;
+	}
 });


### PR DESCRIPTION
I ran into a conflict with Shopp's (http://github.com/ingenesis/shopp) autoloader. 

Adding this line allowed both plugins to work properly. Without it, this autoloader would try to load file paths like:
`/Users/clifgriffin/Sites/mg/wp-content/plugins/shopp-fraudlabspro/class-shoppcore.php`

`stream_resolve_include_path()` returns false if the include path is not valid.  Using `file_exists()` would be valid here too, but this actually verifies that the file exists and is accessible (as I understand it), which should cover more problems. 