### PR TITLE
Clarify directory structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ And that all of the rest of the files are located in a directory structure like 
 |   Utility
 |       ...
 |
-|   Files
-|       class-reader.php
-|       ...
+|       Files
+|           class-reader.php
+|           ...
 |
 |   plugin-bootstrap.php
 ```


### PR DESCRIPTION
The example `Pressware\Utility\Files\Reader` suggests that `Files` is a subdirectory of `Utility`, but the directory structure made it appear as if `Utility` and `Files` were sibling directories. `Files` has been indented to reflect the namespace.