### PR TITLE
Fix: c08905a is missing change of the last variable `$class_file` …

### DIFF
--- a/lib/autoload.php
+++ b/lib/autoload.php
@@ -59,7 +59,7 @@ spl_autoload_register(function( $filename ) {
 		$dir = strtolower( $file_path[ $i ] );
 		$fully_qualified_path .= trailingslashit( $dir );
 	}
-	$fully_qualified_path .= $class_file;
+	$fully_qualified_path .= $file_name;
 
 	// Now include the file.
 	if ( stream_resolve_include_path($fully_qualified_path) ) {


### PR DESCRIPTION
See [comment by @danielfuchs](https://github.com/tommcfarlin/simple-autoloader-for-wordpress/commit/c08905aae04968e38ed7c455940cc3cfb16d9422#commitcomment-23845800).